### PR TITLE
integrate django unfold to improve admin UI

### DIFF
--- a/config/settings.py
+++ b/config/settings.py
@@ -7,6 +7,7 @@ import sentry_sdk
 BASE_DIR = Path(__file__).resolve().parent.parent
 
 INSTALLED_APPS = [
+    "unfold",
     "django.contrib.admin",
     "django.contrib.auth",
     "django.contrib.contenttypes",
@@ -45,6 +46,17 @@ TEMPLATES = [
 
 WSGI_APPLICATION = "config.wsgi.application"
 GOOGLE_CLOUD_PROJECT_ID = os.environ.get("GOOGLE_CLOUD_PROJECT_ID")
+
+UNFOLD = {
+    "SITE_TITLE": "My Admin Dashboard",
+    "SITE_HEADER": "My Admin Panel",
+    "SHOW_HISTORY": True,
+    "DARK_MODE": True,
+    "SIDEBAR": {
+        "show_search": True,
+        "show_all_applications": True,
+    },
+}
 
 if os.getenv('GAE_APPLICATION') is not None:
     DEBUG = False

--- a/events/admin/car.py
+++ b/events/admin/car.py
@@ -1,9 +1,10 @@
 from django.contrib import admin
+from unfold.admin import ModelAdmin
 
 from events.domain.car import Car
 
 
-class CarAdmin(admin.ModelAdmin):
+class CarAdmin(ModelAdmin):
     list_display = ["brand", "model", "competitor__name"]
     list_filter = ["competitor__name"]
 

--- a/events/admin/competitor.py
+++ b/events/admin/competitor.py
@@ -1,18 +1,19 @@
 from django.contrib import admin
+from unfold.admin import ModelAdmin, StackedInline
 
 from events.domain.car import Car
 from events.domain.competitor import Competitor
 from events.domain.inscription import Inscription
 
 
-class CarInline(admin.TabularInline):
+class CarInline(StackedInline):
     model = Car
     extra = 0
     fields = ['brand', 'model', 'group']
     readonly_fields = ['brand', 'model', 'group']
     can_delete = False
 
-class InscriptionInline(admin.TabularInline):
+class InscriptionInline(StackedInline):
     model = Inscription
     fk_name = 'driver'
     extra = 0
@@ -32,7 +33,7 @@ class InscriptionInline(admin.TabularInline):
         return f"{obj.car.brand} {obj.car.model}"
     car_name.short_description = 'Car'
 
-class CompetitorAdmin(admin.ModelAdmin):
+class CompetitorAdmin(ModelAdmin):
     list_display = ["name"]
     search_fields = ["name"]
     inlines = [CarInline, InscriptionInline]

--- a/events/admin/event.py
+++ b/events/admin/event.py
@@ -1,10 +1,11 @@
 from django.contrib import admin
 from django.utils.html import format_html
+from unfold.admin import ModelAdmin
 
 from events.domain.event import Event
 
 
-class EventAdmin(admin.ModelAdmin):
+class EventAdmin(ModelAdmin):
     list_display = ["name", "start_date", "end_date"]
     list_filter = ["name"]
     search_fields = ["name"]

--- a/events/admin/inscription.py
+++ b/events/admin/inscription.py
@@ -1,9 +1,10 @@
 from django.contrib import admin
+from unfold.admin import ModelAdmin
 
 from events.domain.inscription import Inscription
 
 
-class InscriptionAdmin(admin.ModelAdmin):
+class InscriptionAdmin(ModelAdmin):
     list_display = ["event_name", "driver_name", "codriver_name", "car_name"]
     list_filter = ["event"]
 

--- a/events/admin/team.py
+++ b/events/admin/team.py
@@ -1,10 +1,10 @@
 from django.contrib import admin
+from unfold.admin import ModelAdmin
 
-from events.domain.event import Event
 from events.domain.team import Team
 
 
-class TeamAdmin(admin.ModelAdmin):
+class TeamAdmin(ModelAdmin):
     list_display = ["name"]
 
 admin.site.register(Team, TeamAdmin)

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ Pillow==11.3.0
 django-storages[google]==1.14.6
 google-cloud-storage==3.4.0
 sentry-sdk[django]==2.40.0
+django-unfold==0.67.0


### PR DESCRIPTION
solves #34 

This pull request integrates the `unfold` package into the Django admin interface to enhance the appearance and functionality of the admin dashboards. The main changes include updating the admin classes to use `unfold`'s `ModelAdmin` and `StackedInline`, and configuring the `unfold` settings for a customized dashboard experience.

Integration of `unfold` admin package:

* Added `"unfold"` to `INSTALLED_APPS` in `config/settings.py` to enable the package.
* Updated all admin classes in `events/admin/car.py`, `events/admin/competitor.py`, `events/admin/event.py`, `events/admin/inscription.py`, and `events/admin/team.py` to use `unfold.admin.ModelAdmin` instead of Django's default `admin.ModelAdmin`. [[1]](diffhunk://#diff-4db3f983e9a00e34a8a31dffc7e48ad41ffad29dd566c59ece9191d7e08e62a3R2-R7) [[2]](diffhunk://#diff-a795f36681f9c6d1ff84d6aaa65244025d5fc1a6fd38da27095b1786620eee5dL35-R36) [[3]](diffhunk://#diff-d1ca844b86cd95aaee9bc9c850934e06ac3ac8e9e5f748dd1a09abcaf37f7767R3-R8) [[4]](diffhunk://#diff-27acffc06f854ba50a44c162130b786147a5a14aa8b3437ba7a57e22ef9bd7bbR2-R7) [[5]](diffhunk://#diff-32e32f908c575cacd131c989409f6671f55f5ef816d7e2a2b8d6cd7ef5119985R2-R7)
* Changed inline admin classes in `events/admin/competitor.py` from `admin.TabularInline` to `unfold.admin.StackedInline` for improved layout.

Customization of admin dashboard:

* Added the `UNFOLD` settings dictionary in `config/settings.py` to configure site title, header, history visibility, dark mode, and sidebar options for the admin dashboard.